### PR TITLE
Use MSWEP precip data for the observational record

### DIFF
--- a/scripts/concat_mswep.py
+++ b/scripts/concat_mswep.py
@@ -42,3 +42,5 @@ for year in filemap:
         target_path_list=[target_path],
         dependent_task_list=[]
     )
+
+graph.join()

--- a/scripts/concat_mswep.py
+++ b/scripts/concat_mswep.py
@@ -1,0 +1,44 @@
+from collections import defaultdict
+import os
+import re
+
+import taskgraph
+import xarray
+
+data_store_path = 'H://Shared drives/GCM_Climate_Tool/required_files'
+mswep_store = os.path.join(data_store_path, 'OBSERVATIONS', 'Global MSWEP2', 'Daily')
+
+
+def concat_netcdfs(year, target_path):
+    print(year)
+    file_list = [os.path.join(mswep_store, f) for f in filemap[year]]
+    with xarray.open_mfdataset(
+            file_list, parallel=True, combine='nested', concat_dim='time',
+            data_vars='minimal', coords='minimal', compat='override') as dataset:
+        dataset.to_netcdf(target_path)
+
+
+workspace_dir = 'C:/Users/dmf/projects/gcm-project/mswep_annual'
+taskgraph_working_dir = os.path.join(workspace_dir, '..', '.taskgraph')
+graph = taskgraph.TaskGraph(taskgraph_working_dir, -1)
+if not os.path.exists(workspace_dir):
+    os.mkdir(workspace_dir)
+
+filemap = defaultdict(list)
+for file in os.listdir(mswep_store):
+    if re.search(r'[0-9]{7}\.nc', file):
+        year = file[:4]
+        filemap[year].append(file)
+del filemap['1979']  # an incomplete year
+
+for year in filemap:
+    target_path = os.path.join(workspace_dir, f'{year}.nc')
+    graph.add_task(
+        func=concat_netcdfs,
+        kwargs={
+            'year': year,
+            'target_path': target_path
+        },
+        target_path_list=[target_path],
+        dependent_task_list=[]
+    )

--- a/src/example_run.py
+++ b/src/example_run.py
@@ -24,9 +24,9 @@ args = {
     'lower_precip_threshold': 1,  # millimeter
     'aoi_path': os.path.join(
         data_store_path, 'OBSERVATIONS/LLdM_AOI2/SHP/Basin_LldM.shp'),
-    'observed_precip_path': os.path.join(
-        data_store_path, 'OBSERVATIONS/LLdM_AOI2/series_pr_diario_regional_average.nc'),
-    'workspace_dir': 'C://Users/dmf/projects/gcm-project/output'
+    # 'observed_precip_path': os.path.join(
+    #     data_store_path, 'OBSERVATIONS/LLdM_AOI2/series_pr_diario_regional_average.nc'),
+    'workspace_dir': 'C://Users/dmf/projects/gcm-project/output_mswep'
 }
 
 if __name__ == '__main__':

--- a/src/example_run.py
+++ b/src/example_run.py
@@ -17,6 +17,7 @@ args = {
     'prediction_end_date': '2060-01-01',
     'hindcast': False,
     'data_store_path': data_store_path,
+    'mswep_store_path': 'C://Users/dmf/projects/gcm-project/mswep_annual',
     'gcm_var': 'pr',
     'gcm_experiment_list': knn.GCM_EXPERIMENT_LIST,
     'gcm_model_list': ['CanESM5'],

--- a/src/knn.py
+++ b/src/knn.py
@@ -404,8 +404,8 @@ def reduce_netcdf(source_files_list, aoi_netcdf_path, target_filepath):
         # timeseries for now.
         with xarray.open_dataset(aoi_netcdf_path) as aoi_dataset:
             dataset['aoi'] = aoi_dataset.aoi
-            # dataset = dataset.where(dataset.aoi == 1, drop=True)
-            dataset = dataset.sel(aoi=1)
+            dataset = dataset.where(dataset.aoi == 1, drop=True)
+            # dataset = dataset.sel(aoi=1)
             dataset = dataset.mean(['lat', 'lon'])
             dataset.to_netcdf(target_filepath)
 
@@ -439,8 +439,9 @@ def execute(args):
     graph = taskgraph.TaskGraph(taskgraph_working_dir, -1)
 
     # MSWEP Files are named as '%Y%j.nc'; https://strftime.org/
-    mswep_store = os.path.join(
-        args['data_store_path'], 'OBSERVATIONS', 'Global MSWEP2', 'Daily')
+    mswep_store = args['mswep_store_path']
+    # mswep_store = os.path.join(
+    #     args['data_store_path'], 'OBSERVATIONS', 'Global MSWEP2', 'Daily')
     # All files from years in the reference period. Don't worry about excluding
     # extra days if the ref period starts/ends in the middle of a year.
     mswep_files = [
@@ -457,7 +458,7 @@ def execute(args):
     # Only the geotransform is needed from the netcdf, which is
     # the same for all mswep files, so always use the same file for
     # taskgraph benefits.
-    representative_mswep_path = os.path.join(mswep_store, '1979123.nc')
+    representative_mswep_path = os.path.join(mswep_store, '1980.nc')
     rasterize_aoi_mswep_task = graph.add_task(
         func=rasterize_aoi,
         kwargs={


### PR DESCRIPTION
This PR includes a script for concatenating daily mswep netcdfs into annual files, for more efficient data-loading later on. The `knn` module is also updated to use these data.