### PR TITLE
Fixing small bugs related to finding and converting .zarrs and handling dates

### DIFF
--- a/knn/knn.py
+++ b/knn/knn.py
@@ -645,8 +645,9 @@ def extract_from_zarr(zarr_path, aoi_path, target_path, open_chunks=-1):
             & (dataset.lat >= miny - height)
             & (dataset.lat <= maxy + height), drop=True)
 
-        if dataset.time.dtype == 'object' and not dataset.time_bnds:
-            # set time_bnds encoding to match time's
+        # if the time datatype is not set as datetime64,
+        # the time_bnds encoding may need to be set to match that of time
+        if dataset.time.dtype == 'object' and not dataset["time_bnds"].encoding:
             dataset['time_bnds'].encoding.update(dataset.time.encoding)
 
         dataset.to_netcdf(target_path)

--- a/knn/knn.py
+++ b/knn/knn.py
@@ -644,7 +644,14 @@ def extract_from_zarr(zarr_path, aoi_path, target_path, open_chunks=-1):
             & (dataset.lon <= maxx + width)
             & (dataset.lat >= miny - height)
             & (dataset.lat <= maxy + height), drop=True)
-        dataset.to_netcdf(target_path)
+
+        try:
+            dataset.to_netcdf(target_path)
+        except ValueError:
+            LOGGER.warning("Caught ValueError when writing NetCDF, "
+                           "now setting time dtype explicitly.")
+            dataset['time'] = dataset.time.astype('datetime64[ns]')
+            dataset.to_netcdf(target_path)
 
 
 def validate(dataset, prediction_start_date, prediction_end_date):

--- a/knn/knn.py
+++ b/knn/knn.py
@@ -803,22 +803,6 @@ def execute(args):
                 min_date = str(dataset.time.min().values)[:10]
                 max_date = str(dataset.time.max().values)[:10]
             hindcast_date_range = (min_date, max_date)
-        else: # validate dates for MSWEP
-            with xarray.open_dataset(mswep_netcdf_path) as dataset:
-                min_date = str(dataset.time.min().values)[:10]
-                max_date = str(dataset.time.max().values)[:10]
-                print(datetime.strptime(args['reference_period_dates'][0], '%Y-%m-%d'),
-                    datetime.strptime(max_date, '%Y-%m-%d'),
-                        datetime.strptime(args['reference_period_dates'][1], '%Y-%m-%d'),
-                        datetime.strptime(min_date, '%Y-%m-%d'))
-                if (datetime.strptime(args['reference_period_dates'][0], '%Y-%m-%d') >
-                    datetime.strptime(max_date, '%Y-%m-%d') or
-                        datetime.strptime(args['reference_period_dates'][1], '%Y-%m-%d') <
-                        datetime.strptime(min_date, '%Y-%m-%d')):
-                    raise ValueError(
-                        f'the requested reference time period is outside the '
-                        f'time-range of MSWEP ({min_date} : {max_date})'
-                    )
         hind_bootstrap_dates_task = graph.add_task(
             func=bootstrap_dates_precip,
             kwargs={

--- a/knn/knn.py
+++ b/knn/knn.py
@@ -94,11 +94,6 @@ CMIP_ZARR_CHUNKS = {
 }
 
 
-def access_gcsfs():
-    credentials, _ = google.auth.default()
-    return gcsfs.GCSFileSystem(token=credentials)
-
-
 def shift_longitude_from_360(dataset):
     """Reassign longitude coordinates from 0:360 scale to -180:180.
 
@@ -839,7 +834,7 @@ def execute(args):
         gcm_model_list = args['gcm_model_list']
     except KeyError:
         gcm_model_list = []
-    gcs_filesystem = access_gcsfs()
+    gcs_filesystem = gcsfs.GCSFileSystem()
     for gcm_model in gcm_model_list:
         historical_gcm_files = gcs_filesystem.glob(
             f"{BUCKET}/{GCM_PREFIX}/{gcm_model}/{GCM_PRECIP_VAR}_day_{gcm_model}_historical_*.zarr")

--- a/knn/knn.py
+++ b/knn/knn.py
@@ -836,7 +836,7 @@ def execute(args):
     gcs_filesystem = access_gcsfs()
     for gcm_model in gcm_model_list:
         historical_gcm_files = gcs_filesystem.glob(
-            f"{BUCKET}/{GCM_PREFIX}/{gcm_model}/{GCM_PRECIP_VAR}_day_{gcm_model}_historical_*.zarr/")
+            f"{BUCKET}/{GCM_PREFIX}/{gcm_model}/{GCM_PRECIP_VAR}_day_{gcm_model}_historical_*.zarr")
         if len(historical_gcm_files) == 0:
             LOGGER.warning(
                 f'No files found for model: {gcm_model}, experiment: historical'
@@ -879,7 +879,7 @@ def execute(args):
         )
         for gcm_experiment in args['gcm_experiment_list']:
             future_gcm_files = gcs_filesystem.glob(
-                f"{BUCKET}/{GCM_PREFIX}/{gcm_model}/{GCM_PRECIP_VAR}_day_{gcm_model}_{gcm_experiment}_*.zarr/")
+                f"{BUCKET}/{GCM_PREFIX}/{gcm_model}/{GCM_PRECIP_VAR}_day_{gcm_model}_{gcm_experiment}_*.zarr")
 
             if len(future_gcm_files) == 0:
                 LOGGER.warning(

--- a/knn/knn.py
+++ b/knn/knn.py
@@ -645,13 +645,11 @@ def extract_from_zarr(zarr_path, aoi_path, target_path, open_chunks=-1):
             & (dataset.lat >= miny - height)
             & (dataset.lat <= maxy + height), drop=True)
 
-        try:
-            dataset.to_netcdf(target_path)
-        except ValueError:
-            LOGGER.warning("Caught ValueError when writing NetCDF, "
-                           "now setting time dtype explicitly.")
-            dataset['time'] = dataset.time.astype('datetime64[ns]')
-            dataset.to_netcdf(target_path)
+        if dataset.time.dtype == 'object' and not dataset.time_bnds:
+            # set time_bnds encoding to match time's
+            dataset['time_bnds'].encoding.update(dataset.time.encoding)
+
+        dataset.to_netcdf(target_path)
 
 
 def validate(dataset, prediction_start_date, prediction_end_date):

--- a/knn/knn.py
+++ b/knn/knn.py
@@ -325,7 +325,9 @@ def bootstrap_dates_precip(
         historic_gcm_jp_matrix_lookup = historic_obs_jp_matrix_lookup
         gcm_var = MSWEP_VAR
     else:
-        with xarray.open_dataset(gcm_netcdf_path, use_cftime=True) as gcm_dataset:
+        with xarray.open_dataset(
+            gcm_netcdf_path, decode_times=xarray.coders.CFDatetimeCoder(
+                use_cftime=True)) as gcm_dataset:
             gcm_dataset = gcm_dataset.sortby('time')
             validate(gcm_dataset, *prediction_dates)
             LOGGER.info(
@@ -526,7 +528,8 @@ def downscale_precip(
             Not used for hindcasts.
     """
     LOGGER.info('Downscaling...')
-    dates = pandas.read_csv(bootstrapped_dates_path, parse_dates={'date': [0]})
+    dates = pandas.read_csv(bootstrapped_dates_path)
+    dates['date'] = pandas.to_datetime(dates.iloc[:, 0])
     if extreme_value_samples_path:
         extremes = pandas.read_csv(extreme_value_samples_path)
     with xarray.open_dataset(gridded_observed_precip) as dataset:
@@ -642,23 +645,28 @@ def extract_from_zarr(zarr_path, aoi_path, target_path, open_chunks=-1):
 
         # if the time datatype is not set as datetime64,
         # the time_bnds encoding may need to be set to match that of time
-        if dataset.time.dtype == 'object' and not dataset["time_bnds"].encoding:
+        if dataset.time.dtype == 'object' and ("time_bnds" in dataset and
+                                               not dataset["time_bnds"].encoding):
             dataset['time_bnds'].encoding.update(dataset.time.encoding)
 
         dataset.to_netcdf(target_path)
 
 
-def validate(dataset, prediction_start_date, prediction_end_date):
+def validate(dataset, start_date, end_date):
+    """Validate that reference or prediction dates are in dataset's range
+
+    Check that start date occurs before dataset's end date and end date
+    occurs after dataset's start date (with offset)"""
     # TODO: Also validate for hindcasts,
     # that the prediction dates are within bounds of observed data.
     gcm_start_date = datetime.fromisoformat(dataset.time.min().item().isoformat())
     gcm_end_date = datetime.fromisoformat(dataset.time.max().item().isoformat())
     date_offset = timedelta(days=NEAR_WINDOW)
-    if ((datetime.strptime(prediction_start_date, '%Y-%m-%d') + date_offset) > gcm_end_date or
-            (datetime.strptime(prediction_end_date, '%Y-%m-%d') - date_offset) < gcm_start_date):
+    if ((datetime.strptime(start_date, '%Y-%m-%d') + date_offset) > gcm_end_date or
+            (datetime.strptime(end_date, '%Y-%m-%d') - date_offset) < gcm_start_date):
         raise ValueError(
-            f'the requested prediction period {prediction_start_date} : '
-            f'{prediction_end_date} is outside the time-range of the gcm'
+            f'the requested time period {start_date} : '
+            f'{end_date} is outside the time-range of the gcm'
             f'({gcm_start_date} : {gcm_end_date})')
 
 
@@ -724,6 +732,20 @@ def execute(args):
     if not os.path.exists(intermediate_dir):
         os.mkdir(intermediate_dir)
 
+    # Validate reference dates if using MSWEP data
+    if 'observed_dataset_path' not in args or \
+            args['observed_dataset_path'] is None:
+        min_date = "1980-01-01"  # hard-coding these for MSWEP
+        max_date = "2020-12-30"
+        if (datetime.strptime(args['reference_period_dates'][0], '%Y-%m-%d') >
+            datetime.strptime(max_date, '%Y-%m-%d') or
+                datetime.strptime(args['reference_period_dates'][1], '%Y-%m-%d') <
+                datetime.strptime(min_date, '%Y-%m-%d')):
+            raise ValueError(
+                f'the requested reference time period is outside the '
+                f'time-range of MSWEP ({min_date} : {max_date})'
+            )
+
     mswep_extract_path = os.path.join(intermediate_dir, 'extracted_mswep.nc')
     aoi_mask_mswep_path = os.path.join(intermediate_dir, 'aoi_mask_mswep.nc')
     mswep_netcdf_path = os.path.join(intermediate_dir, 'mswep_mean.nc')
@@ -782,6 +804,22 @@ def execute(args):
                 min_date = str(dataset.time.min().values)[:10]
                 max_date = str(dataset.time.max().values)[:10]
             hindcast_date_range = (min_date, max_date)
+        else: # validate dates for MSWEP
+            with xarray.open_dataset(mswep_netcdf_path) as dataset:
+                min_date = str(dataset.time.min().values)[:10]
+                max_date = str(dataset.time.max().values)[:10]
+                print(datetime.strptime(args['reference_period_dates'][0], '%Y-%m-%d'),
+                    datetime.strptime(max_date, '%Y-%m-%d'),
+                        datetime.strptime(args['reference_period_dates'][1], '%Y-%m-%d'),
+                        datetime.strptime(min_date, '%Y-%m-%d'))
+                if (datetime.strptime(args['reference_period_dates'][0], '%Y-%m-%d') >
+                    datetime.strptime(max_date, '%Y-%m-%d') or
+                        datetime.strptime(args['reference_period_dates'][1], '%Y-%m-%d') <
+                        datetime.strptime(min_date, '%Y-%m-%d')):
+                    raise ValueError(
+                        f'the requested reference time period is outside the '
+                        f'time-range of MSWEP ({min_date} : {max_date})'
+                    )
         hind_bootstrap_dates_task = graph.add_task(
             func=bootstrap_dates_precip,
             kwargs={
@@ -849,6 +887,21 @@ def execute(args):
                 f'Found: {historical_gcm_files}'
                 f'skipping model {gcm_model}.')
             continue
+
+        # validate that reference dates fall within range of historical data
+        with xarray.open_dataset(f'{GCS_PROTOCOL}{historical_gcm_files[0]}',
+                                 decode_times=xarray.coders.CFDatetimeCoder(
+                                     use_cftime=True),
+                                 engine='zarr') as gcm_hist_dataset:
+            validate(gcm_hist_dataset, *args['reference_period_dates'])
+        # validate forecast dates fall within range of future data
+        future_gcm_files = gcs_filesystem.glob(
+                f"{BUCKET}/{GCM_PREFIX}/{gcm_model}/{GCM_PRECIP_VAR}_day_{gcm_model}_ssp*.zarr")
+        with xarray.open_dataset(f'{GCS_PROTOCOL}{future_gcm_files[0]}',
+                                 decode_times=xarray.coders.CFDatetimeCoder(
+                                     use_cftime=True),
+                                 engine='zarr') as future_gcm_dataset:
+            validate(future_gcm_dataset, *args['prediction_dates'])
 
         gcm_historical_extract_path = os.path.join(
             intermediate_dir, f'extracted_{gcm_model}_historical.nc')

--- a/knn/knn.py
+++ b/knn/knn.py
@@ -329,7 +329,6 @@ def bootstrap_dates_precip(
             gcm_netcdf_path, decode_times=xarray.coders.CFDatetimeCoder(
                 use_cftime=True)) as gcm_dataset:
             gcm_dataset = gcm_dataset.sortby('time')
-            validate(gcm_dataset, *prediction_dates)
             LOGGER.info(
                 f'computing GCM JP matrices for reference period '
                 f'{reference_period_dates[0]} : {reference_period_dates[1]}')

--- a/knn/knn.py
+++ b/knn/knn.py
@@ -855,7 +855,7 @@ def execute(args):
         gcm_model_list = args['gcm_model_list']
     except KeyError:
         gcm_model_list = []
-    gcs_filesystem = gcsfs.GCSFileSystem()
+    gcs_filesystem = gcsfs.GCSFileSystem(token='anon')
     for gcm_model in gcm_model_list:
         historical_gcm_files = gcs_filesystem.glob(
             f"{BUCKET}/{GCM_PREFIX}/{gcm_model}/{GCM_PRECIP_VAR}_day_{gcm_model}_historical_*.zarr")

--- a/knn/knn.py
+++ b/knn/knn.py
@@ -735,15 +735,14 @@ def execute(args):
     # Validate reference dates if using MSWEP data
     if 'observed_dataset_path' not in args or \
             args['observed_dataset_path'] is None:
-        min_date = "1980-01-01"  # hard-coding these for MSWEP
-        max_date = "2020-12-30"
-        if (datetime.strptime(args['reference_period_dates'][0], '%Y-%m-%d') >
-            datetime.strptime(max_date, '%Y-%m-%d') or
-                datetime.strptime(args['reference_period_dates'][1], '%Y-%m-%d') <
-                datetime.strptime(min_date, '%Y-%m-%d')):
+        min_mswep_date = datetime.strptime(MSWEP_DATE_RANGE[0], '%Y-%m-%d')
+        max_mswep_date = datetime.strptime(MSWEP_DATE_RANGE[1], '%Y-%m-%d')
+        ref_start = datetime.strptime(args['reference_period_dates'][0], '%Y-%m-%d')
+        ref_end = datetime.strptime(args['reference_period_dates'][1], '%Y-%m-%d')
+        if (ref_start > max_mswep_date or ref_end < min_mswep_date):
             raise ValueError(
                 f'the requested reference time period is outside the '
-                f'time-range of MSWEP ({min_date} : {max_date})'
+                f'time-range of MSWEP ({min_mswep_date} : {max_mswep_date})'
             )
 
     mswep_extract_path = os.path.join(intermediate_dir, 'extracted_mswep.nc')

--- a/knn/plot.py
+++ b/knn/plot.py
@@ -17,8 +17,8 @@ def plot(dates_filepath, precip_filepath, observed_mean_precip_filepath,
          hindcast, target_filename):
     LOGGER.info(f'creating report for {precip_filepath}')
 
-    bootstrapped_data = pandas.read_csv(
-        dates_filepath, parse_dates={'date': [0]})
+    bootstrapped_data = pandas.read_csv(dates_filepath)
+    bootstrapped_data['date'] = pandas.to_datetime(bootstrapped_data.iloc[:, 0])
     bootstrapped_data.set_index('date', inplace=True)
     bootstrapped_data.drop(columns=[
         'historic_date',
@@ -46,7 +46,12 @@ def plot(dates_filepath, precip_filepath, observed_mean_precip_filepath,
         # is relevant
         ref_start_date = pandas.to_datetime(reference_period_dates[0])
         ref_end_date = pandas.to_datetime(reference_period_dates[1])
-        mswep_df = mswep_df[ref_start_date:ref_end_date]
+        # mswep_df = mswep_df[ref_start_date:ref_end_date]
+        mswep_df = mswep_df.loc[
+            (mswep_df.index >= ref_start_date) &
+            (mswep_df.index <= ref_end_date)
+        ]
+
 
     data['month'] = data.index.month
     data_long = pandas.melt(

--- a/knn/plot.py
+++ b/knn/plot.py
@@ -44,7 +44,9 @@ def plot(dates_filepath, precip_filepath, observed_mean_precip_filepath,
         data_series_list = ['python_prediction']
         # For forecasts, only the reference period of the observed data
         # is relevant
-        mswep_df = mswep_df[reference_period_dates[0]: reference_period_dates[1]]
+        ref_start_date = pandas.to_datetime(reference_period_dates[0])
+        ref_end_date = pandas.to_datetime(reference_period_dates[1])
+        mswep_df = mswep_df[ref_start_date:ref_end_date]
 
     data['month'] = data.index.month
     data_long = pandas.melt(

--- a/knn/tests/test_downscaling.py
+++ b/knn/tests/test_downscaling.py
@@ -169,7 +169,7 @@ class TestKNN(unittest.TestCase):
 
         # reference range can be pre-1980 bc using own observed data (not MSWEP)
         start = '1910-01-01'
-        end = '1979-12-31'  
+        end = '1979-12-31'
         dates = pandas.date_range(start, end, freq='D')
         lons = [0.0, 2.0, 4.0, 6.0]
         lats = [0.0, 2.0, 4.0, 6.0]
@@ -188,6 +188,7 @@ class TestKNN(unittest.TestCase):
         precip_dataset = xarray.Dataset({knn.MSWEP_VAR: da})
         precip_dataset.to_netcdf(observed_dataset_path)
 
+        # Does not raise error as forecast period overlaps dataset period
         forecast_start = '2010-01-01'
         forecast_end = '2018-12-31'
 

--- a/knn/tests/test_downscaling.py
+++ b/knn/tests/test_downscaling.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 from unittest.mock import patch, MagicMock
 
+import gcsfs
 from osgeo import osr
 import numpy
 import pandas
@@ -153,12 +154,11 @@ class TestKNN(unittest.TestCase):
             dataset.time, transitions, month, day, near_window)
         numpy.testing.assert_array_almost_equal(jp_matrix, expected_matrix)
 
-    @patch('knn.knn.GCS_PROTOCOL', 'file:///')
     def test_execute(self):
         """Test the whole execute method."""
 
         from knn import knn
-        thing = knn.GCSFS
+        thing = gcsfs.GCSFileSystem(project='natcap-servers')
 
         observed_dataset_path = os.path.join(self.workspace_dir, 'obs.nc')
         historical_gcm_path = os.path.join(
@@ -211,8 +211,8 @@ class TestKNN(unittest.TestCase):
         historic_gcm_dataset = xarray.Dataset({knn.GCM_PRECIP_VAR: historic_da})
         historic_gcm_dataset.to_zarr(historical_gcm_path)
 
-        forecast_start = '2000-01-01'
-        forecast_end = '2001-12-31'
+        forecast_start = '2010-01-01'
+        forecast_end = '2018-12-31'
         forecast_dates = pandas.date_range(
             forecast_start, forecast_end, freq='D')
         precip_array = numpy.random.negative_binomial(

--- a/knn/tests/test_downscaling.py
+++ b/knn/tests/test_downscaling.py
@@ -2,9 +2,7 @@ import os
 import shutil
 import tempfile
 import unittest
-from unittest.mock import patch, MagicMock
 
-import gcsfs
 from osgeo import osr
 import numpy
 import pandas


### PR DESCRIPTION
1. Remove forward slash at end of .zarr paths (files were not detected if the slash was included in the filename expression)
2. If not able to convert zarrs to netcdf, ~try to explicitly set `time`'s datatype:~  set `time_bnds` encoding to match the encoding of`time`

Context:
The MSWEP data had `datetime64[ns]` as the time datatype, but the CMIP6's time dimension is encoded as `CFTime` and the dtype is set as `object` which was causing this error when trying to convert to netcdf:

`ValueError: When encoding chunked arrays of datetime values, both the units and dtype must be prescribed or both must be unprescribed. Prescribing only one or the other is not currently supported. Got a units encoding of days since 1850-01-01 and a dtype encoding of None.`

This seems related to the discussion in #3 


3. Explicitly convert the reference dates from `string` to `pandas.datetime` in order to slice MSWEP data for plotting
4. Add error handling for reference and forecast input date ranges to ensure that they overlap with the CMIP6 or MSWEP date ranges
5. Add test to check error handling of various dates