### PR TITLE
Check that future GCM files exist before date validation; update README

### DIFF
--- a/knn/knn.py
+++ b/knn/knn.py
@@ -885,6 +885,10 @@ def execute(args):
         # validate forecast dates fall within range of future data
         future_gcm_files = gcs_filesystem.glob(
                 f"{BUCKET}/{GCM_PREFIX}/{gcm_model}/{GCM_PRECIP_VAR}_day_{gcm_model}_ssp*.zarr")
+        if len(future_gcm_files) == 0:
+            LOGGER.warning(
+                f'No files found for model: {gcm_model}. Skipping.')
+            continue
         with xarray.open_dataset(
                 f'{GCS_PROTOCOL}{future_gcm_files[0]}',
                 decode_times=xarray.coders.CFDatetimeCoder(use_cftime=True),

--- a/readme.md
+++ b/readme.md
@@ -6,18 +6,6 @@ Downscaling methods are based on those described in:
 * _A Technique for Generating Regional Climate Scenarios Using a Nearest-Neighbour Algorithm_ [http://dx.doi.org/10.1029/2002WR001769]
 * _Statistical downscaling using K-nearest neighbors_ [https://doi.org/10.1029/2004WR003444]
 
-## Setup
-
-1. Request access to climate data
-    * Send Dave a google account email address you wish to use for Google Cloud.  
-    (gmail or @stanford.edu addresses should work)
-    * _(Users will be granted Role `Storage Object Viewer` for bucket `natcap-climate-data`)_
-
-2. Authenticate with Google Cloud
-    * install `gcloud` if needed (https://cloud.google.com/sdk/docs/install)
-```
-gcloud auth application-default login
-```
 
 ## Usage option 1: with a conda environment
 
@@ -113,7 +101,7 @@ This workflow derives downscaled climate data from,
 * MSWEP historical precipitation data.
 
 ## Data Storage
-Analysis-ready data are stored in `zarr` format in a private google cloud bucket
+Analysis-ready data are stored in `zarr` format in a public google cloud bucket
 (`natcap-climate-data`) in the `NatCap Servers` cloud project.  
 
 Raw netCDF data are stored on Stanford's Oak Storage Service at


### PR DESCRIPTION
As a result of the previous PR that added more exact dates validation, an error was thrown when the model was validating forecast dates if there weren't any 'future' GCM data (specifically, when selecting the 'CESM5' model, as only historical data exists). I added some error handling/logging to record and skip this. I left in the existing error handling that checks data for specific models/experiments.  

I also updated the README to remove the instructions pertaining to google authentication to access the GCS bucket, which are now outdated as the bucket is public. 