### PR TITLE
Add licenses for MSWEP and CMIP6 to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -100,14 +100,15 @@ This workflow derives downscaled climate data from,
 * CMIP6 General Circulation Models (ee `knn.MODEL_LIST` for list of available models)
 * MSWEP historical precipitation data.
 
-## Data License and Attribution
+## Data License
 
-MSWEP data are distributed under the
+MSWEP is released under the
 [Creative Commons Attribution-NonCommerical (CC By-NC) 4.0 license](https://creativecommons.org/licenses/by-nc/4.0/deed.en)
 and can be used for academic research, nonprofit scientific studies,
-personal projects, and certain government or NGO applications.
+personal projects, and certain government or NGO applications. For more
+information, please visit https://www.gloh2o.org/.
 
-CMIP6 data are distributed under the
+CMIP6 multi-model data are licensed under a
 [Creative Commons Attribution 4.0 International (CC BY 4.0) license](https://creativecommons.org/licenses/by/4.0/).
 For more information, please see the
 [CMIP6: Terms of Use](https://pcmdi.llnl.gov/CMIP6/TermsOfUse/TermsOfUse6-2.html)

--- a/readme.md
+++ b/readme.md
@@ -100,6 +100,18 @@ This workflow derives downscaled climate data from,
 * CMIP6 General Circulation Models (ee `knn.MODEL_LIST` for list of available models)
 * MSWEP historical precipitation data.
 
+## Data License and Attribution
+
+MSWEP data are distributed under the
+[Creative Commons Attribution-NonCommerical (CC By-NC) 4.0 license](https://creativecommons.org/licenses/by-nc/4.0/deed.en)
+and can be used for academic research, nonprofit scientific studies,
+personal projects, and certain government or NGO applications.
+
+CMIP6 data are distributed under the
+[Creative Commons Attribution 4.0 International (CC BY 4.0) license](https://creativecommons.org/licenses/by/4.0/).
+For more information, please see the
+[CMIP6: Terms of Use](https://pcmdi.llnl.gov/CMIP6/TermsOfUse/TermsOfUse6-2.html)
+
 ## Data Storage
 Analysis-ready data are stored in `zarr` format in a public google cloud bucket
 (`natcap-climate-data`) in the `NatCap Servers` cloud project.  


### PR DESCRIPTION
For CMIP6, I tried to summarize the info in the [Terms of Use](https://pcmdi.llnl.gov/CMIP6/TermsOfUse/TermsOfUse6-2.html) and for MSWEP I looked at the Data access information on their website (https://www.gloh2o.org/).

I will also plan to add this same information to the plugin README as well.